### PR TITLE
Pre-empted driver quitting with a .close

### DIFF
--- a/packages/jest-environment-webdriver/modules/WebDriverEnvironment.js
+++ b/packages/jest-environment-webdriver/modules/WebDriverEnvironment.js
@@ -28,12 +28,14 @@ class WebDriverEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
-    await this.driver.close();
+    if (this.driver) {
+      await this.driver.close();
 
-    // https://github.com/mozilla/geckodriver/issues/1151
-    try {
-      await this.driver.quit();
-    } catch (error) { }
+      // https://github.com/mozilla/geckodriver/issues/1151
+      try {
+        await this.driver.quit();
+      } catch (error) { }
+    }
 
     await super.teardown();
   }

--- a/packages/jest-environment-webdriver/modules/WebDriverEnvironment.js
+++ b/packages/jest-environment-webdriver/modules/WebDriverEnvironment.js
@@ -28,7 +28,13 @@ class WebDriverEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
-    await this.driver.quit();
+    await this.driver.close();
+
+    // https://github.com/mozilla/geckodriver/issues/1151
+    try {
+      await this.driver.quit();
+    } catch (error) { }
+
     await super.teardown();
   }
 }

--- a/packages/jest-environment-webdriver/modules/WebDriverEnvironment.js
+++ b/packages/jest-environment-webdriver/modules/WebDriverEnvironment.js
@@ -29,7 +29,10 @@ class WebDriverEnvironment extends NodeEnvironment {
 
   async teardown() {
     if (this.driver) {
-      await this.driver.close();
+      // https://github.com/alexeyraspopov/jest-webdriver/issues/8
+      try {
+        await this.driver.close();
+      } catch (error) { }
 
       // https://github.com/mozilla/geckodriver/issues/1151
       try {


### PR DESCRIPTION
See https://github.com/mozilla/geckodriver/issues/1151. It looks like at least Firefox will annoyingly remain open if a page has certain kinds of modal dialogs.
Although it's a teeny bit messy, I don't think it can hurt to _really_ close the browser.