### PR TITLE
Accept default capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Connect [Jest][1] tests to [Selenium WebDriver][2].
 
 ## Limitations
 
-The project is in progress. It only supports running [preinstalled][3] WebDrivers (Chrome, Safari, Firefox, Edge, IE) without additional options. Capabilities configuration will be added soon. Pull requests welcomed.
+The project is in progress. It only supports running [preinstalled][3] WebDrivers (Chrome, Safari, Firefox, Edge, IE) without additional options. It accepts [webdriver1 capabilities](https://www.w3.org/TR/webdriver1/#capabilities). Pull requests welcomed.
 
 ## Usage
 

--- a/packages/jest-environment-webdriver/README.md
+++ b/packages/jest-environment-webdriver/README.md
@@ -13,6 +13,18 @@ Set [`testEnvironment`](https://facebook.github.io/jest/docs/en/configuration.ht
       "browser": "safari"
     }
 
+You can pass [capabilities](https://www.w3.org/TR/webdriver1/#capabilities) as options too:    
+
+    "testEnvironment": "jest-environment-webdriver",
+    "testEnvironmentOptions": {
+      browser: 'firefox',
+      capabilities: {
+        browserName: 'Some user agent',
+        acceptInsecureCerts: true
+      }
+    }
+
+
 ## Environment API
 
 Next global objects and functions are available in testing code.

--- a/packages/jest-environment-webdriver/modules/WebDriverEnvironment.js
+++ b/packages/jest-environment-webdriver/modules/WebDriverEnvironment.js
@@ -7,14 +7,18 @@ class WebDriverEnvironment extends NodeEnvironment {
     const options = config.testEnvironmentOptions || {};
     this.browserName = options.browser || 'chrome';
     this.seleniumAddress = options.seleniumAddress || null;
+    this.capabilities = options.capabilities || null;
   }
 
   async setup() {
     await super.setup();
-    
+
     let driver = new Builder();
     if (this.seleniumAddress) {
       driver = driver.usingServer(this.seleniumAddress);
+    }
+    if (this.capabilities) {
+      driver = driver.withCapabilities(this.capabilities);
     }
     driver = await driver.forBrowser(this.browserName).build();
 


### PR DESCRIPTION
This will enable default capabilities available for all drivers: https://www.w3.org/TR/webdriver1/#capabilities.

Usage example (included in `README` file):

```javascript
    "testEnvironment": "jest-environment-webdriver",
    "testEnvironmentOptions": {
      browser: 'firefox',
      capabilities: {
        browserName: 'Some user agent',
        acceptInsecureCerts: true
      }
    }
```